### PR TITLE
Update layout of KYC Case pending view

### DIFF
--- a/src/components/CustomerRisk/CustomerRisk.scss
+++ b/src/components/CustomerRisk/CustomerRisk.scss
@@ -1,3 +1,4 @@
 .craTitle {
   font-weight: bold;
+  padding-bottom: 2px;
 }

--- a/src/components/CustomerRisk/CustomerRisk.tsx
+++ b/src/components/CustomerRisk/CustomerRisk.tsx
@@ -5,14 +5,16 @@ import React from 'react';
 
 import './CustomerRisk.scss';
 import {CustomerRiskAssessmentModel} from "../../models";
+import {Stack} from "../Stack";
 
 export interface CustomerRiskProps {
+    hideTitle?: boolean;
     customerRisk?: CustomerRiskAssessmentModel
 }
 
 export const CustomerRisk: React.FunctionComponent<CustomerRiskProps> = (props: CustomerRiskProps) => {
 
-    const getContent = (): string => {
+    const getContent = () => {
         if (!props.customerRisk) {
             return 'Pending'
         }
@@ -21,13 +23,17 @@ export const CustomerRisk: React.FunctionComponent<CustomerRiskProps> = (props: 
             return 'Error'
         }
 
-        return `${props.customerRisk.rating} - ${props.customerRisk.score}`
+        return (
+            <Stack gap={3}>
+                <div><span className="label">Rating:</span>{props.customerRisk.rating}</div>
+                <div><span className="label">Score:</span>{props.customerRisk.score}</div>
+            </Stack>)
     }
 
     return (
         <div style={{width: '100%', textAlign: 'left'}}>
-            <div className="craTitle">Customer risk</div>
-            <div>{getContent()}</div>
+            {!props.hideTitle ? (<div className="craTitle">Customer risk</div>) : (<></>)}
+            <div className="summary">{getContent()}</div>
         </div>
     )
 }

--- a/src/components/KycSummary/KycSummary.scss
+++ b/src/components/KycSummary/KycSummary.scss
@@ -1,4 +1,9 @@
 
 .kycSummaryTitle {
   font-weight: bold;
+  padding-bottom: 2px;
+}
+
+p.summary {
+  padding: 2px 0;
 }

--- a/src/components/KycSummary/KycSummary.tsx
+++ b/src/components/KycSummary/KycSummary.tsx
@@ -7,6 +7,7 @@ import './KycSummary.scss';
 import {KycCaseSummaryModel} from "../../models";
 
 export interface KycSummaryProps {
+    hideTitle?: boolean;
     kycSummary: KycCaseSummaryModel;
 }
 
@@ -24,10 +25,12 @@ export const KycSummary: React.FunctionComponent<KycSummaryProps> = (props: KycS
         return props.kycSummary.summary || '--'
     }
 
+    const content = getContent().split('\n')
+
     return (
         <div style={{width: '100%', textAlign: 'left'}}>
-            <div className="kycSummaryTitle">KYC Summary</div>
-            <p>{getContent()}</p>
+            {!props.hideTitle ? (<div className="kycSummaryTitle">KYC Summary</div>) : (<></>)}
+            {content.map((val, index) => (<p key={index} className="summary">{val}</p>))}
         </div>
     )
 }

--- a/src/components/NegativeNews/NegativeNews.tsx
+++ b/src/components/NegativeNews/NegativeNews.tsx
@@ -8,6 +8,7 @@ import {NegativeScreeningModel} from "../../models";
 
 export interface NegativeNewsProps {
     type: string;
+    hideTitle?: boolean;
     news?: NegativeScreeningModel;
 }
 
@@ -31,7 +32,7 @@ export const NegativeNews: React.FunctionComponent<NegativeNewsProps> = (props: 
 
     return (
         <div style={{width: '100%', textAlign: 'left'}}>
-            <div className="negNewsTitle">Negative news - {props.type}</div>
+            {!props.hideTitle ? (<div className="negNewsTitle">Negative news - {props.type}</div>) : (<></>)}
             <div>{getContent()}</div>
         </div>
     )

--- a/src/models/kyc-case.model.ts
+++ b/src/models/kyc-case.model.ts
@@ -34,10 +34,18 @@ export interface NegativeScreeningModel {
     error?: string;
 }
 
+export const isNegativeScreeningModel = (val: unknown): val is NegativeScreeningModel => {
+    return !!val && !!(val as NegativeScreeningModel).result
+}
+
 export interface CustomerRiskAssessmentModel {
     rating: string;
     score: number;
     error?: string;
+}
+
+export const isCustomerRiskAssessmentModel = (val: unknown): val is CustomerRiskAssessmentModel => {
+    return !!val && !!(val as CustomerRiskAssessmentModel).score
 }
 
 export interface ReviewCaseModel {
@@ -56,6 +64,10 @@ export interface ApproveCaseModel {
 export interface KycCaseSummaryModel {
     summary: string;
     error?: string;
+}
+
+export const isKycCaseSummaryModel = (val: unknown): val is KycCaseSummaryModel => {
+    return !!val && !!(val as KycCaseSummaryModel).summary
 }
 
 export interface DocumentRef {

--- a/src/views/KYC/KYCCaseDetail/KYCCasePending/KYCCasePending.tsx
+++ b/src/views/KYC/KYCCaseDetail/KYCCasePending/KYCCasePending.tsx
@@ -1,14 +1,20 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import React from 'react';
+import React, {ComponentType} from 'react';
 import {useNavigate} from "react-router-dom";
-import {Button} from "@carbon/react";
+import {Button, Tab, TabList, TabPanel, TabPanels, Tabs} from "@carbon/react";
 import {useSetAtom} from "jotai";
+import {Error, Pending} from "@carbon/icons-react";
 
 import './KYCCasePending.scss';
 import {selectedKycCaseAtom} from "../../../../atoms";
 import {CustomerRisk, DocumentList, KycSummary, NegativeNews, Stack} from "../../../../components";
-import {KycCaseModel} from "../../../../models";
+import {
+    CustomerRiskAssessmentModel, isCustomerRiskAssessmentModel, isKycCaseSummaryModel, isNegativeScreeningModel,
+    KycCaseModel,
+    KycCaseSummaryModel,
+    NegativeScreeningModel
+} from "../../../../models";
 import {kycCaseManagementApi} from "../../../../services";
 
 export interface KYCCasePendingProps {
@@ -31,6 +37,30 @@ export const KYCCasePending: React.FunctionComponent<KYCCasePendingProps> = (pro
             .catch(err => console.error('Error processing case: ', {err}))
     }
 
+    const getIcon = (data?: {error?: string}): ComponentType<{size: number}> => {
+
+        if (!data) {
+            return Pending as any;
+        }
+
+        if (data.error) {
+            return Error as any;
+        }
+
+        return undefined
+    }
+
+    const isDisabled = (data?: {error?: string}): boolean => {
+        return !data;
+    }
+
+    const tabProps = (data: {error?: string}) => {
+        return {
+            renderIcon: getIcon(data),
+            disabled: isDisabled(data),
+        }
+    }
+
     return (
             <Stack gap={7}>
                 <h2>Pending information</h2>
@@ -46,12 +76,21 @@ export const KYCCasePending: React.FunctionComponent<KYCCasePendingProps> = (pro
                     </Stack>
                 </div>
                 <DocumentList documents={props.currentCase.documents} />
-                <div><Button onClick={handleRefresh}>Refresh</Button></div>
-                <NegativeNews type="Party" news={props.currentCase.negativeScreening} />
-                <NegativeNews type="Counterparty" news={props.currentCase.counterpartyNegativeScreening} />
-                <CustomerRisk customerRisk={props.currentCase.customerRiskAssessment} />
-                <KycSummary kycSummary={props.currentCase.caseSummary} />
-                <div><Button kind="tertiary" onClick={handleCancel}>Return</Button></div>
+                <Tabs>
+                    <TabList aria-label="List of tabs">
+                        <Tab {...tabProps(props.currentCase.customerRiskAssessment)}>Customer Risk</Tab>
+                        <Tab {...tabProps(props.currentCase.negativeScreening)}>Negative News - Party</Tab>
+                        <Tab {...tabProps(props.currentCase.counterpartyNegativeScreening)}>Negative News - Counterparty</Tab>
+                        <Tab {...tabProps(props.currentCase.caseSummary)}>KYC Summary</Tab>
+                    </TabList>
+                    <TabPanels>
+                        <TabPanel><CustomerRisk hideTitle={true} customerRisk={props.currentCase.customerRiskAssessment} /></TabPanel>
+                        <TabPanel><NegativeNews hideTitle={true} type="Party" news={props.currentCase.negativeScreening} /></TabPanel>
+                        <TabPanel><NegativeNews hideTitle={true} type="Counterparty" news={props.currentCase.counterpartyNegativeScreening} /></TabPanel>
+                        <TabPanel><KycSummary hideTitle={true} kycSummary={props.currentCase.caseSummary} /></TabPanel>
+                    </TabPanels>
+                </Tabs>
+                <div><Button kind="tertiary" onClick={handleCancel}>Return</Button> <Button onClick={handleRefresh}>Refresh</Button></div>
             </Stack>
     )
 }


### PR DESCRIPTION
- Update presentation of KYC Summary into separate paragraphs
- Organize results (customer risk, negative news, and summary) in tabs

closes #71